### PR TITLE
Ensure that preRender is called on all plugins

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -187,6 +187,9 @@ function dtNGRenderer($log, $q, $compile, $timeout, DTRenderer, DTRendererServic
                 }
                 $timeout(function() {
                     _alreadyRendered = true;
+                    // Ensure that prerender is called when the collection is updated
+                    // See https://github.com/l-lin/angular-datatables/issues/502
+                    DTRendererService.preRender(renderer.options);
                     var result = DTRendererService.hideLoadingAndRenderDataTable(_$elem, renderer.options);
                     _oTable = result.DataTable;
                     DTInstanceFactory.copyDTProperties(result, dtInstance);


### PR DESCRIPTION
Fixed an issue where preRender was not being called when an "Angular Way" table had its collection updated.
